### PR TITLE
Fix colors when receiving multiple contacts

### DIFF
--- a/WhatsApp.user.css
+++ b/WhatsApp.user.css
@@ -458,7 +458,8 @@
       height: auto;
       background-color: var(--darker) !important; }
       /* Send contacts. #42 */
-      .WOXAS {
+      .WOXAS,
+      ._1v8mQ {
         background-color: transparent !important; }
       /* Footer. */
       ._21bWq, ._22oFl {
@@ -836,7 +837,8 @@
     .message-in .selectable-text,
     .message-out .selectable-text,
     .quoted-mention,
-    ._1upWv {
+    ._1upWv,
+    ._3ZVco {
       color: var(--light) !important; }
 
     /* Voice messages. */


### PR DESCRIPTION
I'd never received multiple contacts until today.

How it looks in vanilla Whatsapp:
![whatsapp-recieve-multi-contacts](https://user-images.githubusercontent.com/12503367/68959774-c1722f80-079c-11ea-863b-563a6b8b343c.png)
![whatsapp-show-multi-contacts](https://user-images.githubusercontent.com/12503367/68959775-c1722f80-079c-11ea-9287-34c5ac6d4a59.png)

How it looks in Onyx:
![onyx-recieve-multi-contacts](https://user-images.githubusercontent.com/12503367/68959830-d9e24a00-079c-11ea-94fd-ba1c46439b30.png)
![onyx-show-multi-contacts](https://user-images.githubusercontent.com/12503367/68959831-d9e24a00-079c-11ea-8a3c-32cc75a25049.png)

This PR sets the colors to be in line with how Onyx handles these types of boxes.
