### PR TITLE
Fix colour of unlistened voice message icons

### DIFF
--- a/WhatsApp.user.css
+++ b/WhatsApp.user.css
@@ -1498,6 +1498,9 @@
     fill: var(--dark) !important; }
   span[data-icon^="ptt-"] svg path:last-child {
     fill: var(--accent) !important; }
+  
+  span[data-icon="ptt-out-gray"] svg path:last-child {
+    fill: var(--icon) !important; }
 
   /* Logo. */
   ._3CSsZ > svg > path:first-child {


### PR DESCRIPTION
I noticed that you couldn't distinguish between voice messages that were already listened to and those that weren't.

I basically just looked around what colours were used and now it looks pretty good to me. :)

(Also, thank you for this style, I *love* it)